### PR TITLE
Fix tailwind component path

### DIFF
--- a/site-putz/tailwind.config.js
+++ b/site-putz/tailwind.config.js
@@ -1,0 +1,12 @@
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    // "./components/**/*.{js,ts,jsx,tsx}", // pasta de componentes ainda sera criada
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- update path comments in `site-putz/tailwind.config.js`

## Testing
- `npm run build` *(fails: found page without a React Component as default export in pages/)*

------
https://chatgpt.com/codex/tasks/task_e_68484f585dd4832c8f59f42fd3da57de